### PR TITLE
Cse 2391 fix readme and separate linter config

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -20,9 +20,9 @@ module.exports = {
     sourceType: 'module'
   },
   env: {
-    browser: false,
+    browser: true,
     node: true,
-    es6: false
+    es6: true
   },
   rules: fileRules
 }

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,9 +1,7 @@
+const prettierRule = require('./prettier.config');
+
 const fileRules = {
-  'prettier/prettier': ['warn', {
-    singleQuote: true,
-    semi: true,
-    printWidth: 100
-  }]
+  'prettier/prettier': ['warn', prettierRule]
 };
 
 module.exports = {

--- a/README.md
+++ b/README.md
@@ -7,13 +7,13 @@
 Install td-workflow-development-kit using `npm`:
 
 ``` bash
-npm install chatwork/td-workflow-development-kit
+npm install -g chatwork/td-workflow-development-kit
 ```
 
 Or `yarn`:
 
 ``` bash
-yarn add chatwork/td-workflow-development-kit
+yarn global add chatwork/td-workflow-development-kit
 ```
 
 See help message for details.

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "npm": ">= 6.13.4"
   },
   "scripts": {
-    "lint": "eslint --fix src/**/*.ts && eslint --fix test/**/*.ts",
+    "lint": "eslint --fix 'src/**/*.ts' --no-error-on-unmatched-pattern && eslint --fix 'test/**/*.ts' --no-error-on-unmatched-pattern",
     "test": "jest --passWithNoTests",
     "build": "npm run clean && npm run lint && npm run test && tsc",
     "install": "tsc",

--- a/prettier.config.js
+++ b/prettier.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+  singleQuote: true,
+  semi: true,
+  printWidth: 100
+};


### PR DESCRIPTION
<!-- cspell: disable-next-line-->
<!-- markdownlint-disable MD041-->
## ⛏やったこと

- GAS の方で須藤さんに指摘されて反映した eslint とprettier の設定ファイルの分離をこちらにも適用しました
- global でインストールしないと CLI でコマンドを認識しないため Readme を修正しました
- 環境によっては Linter が走らないことがあるので、eslint に渡す際に glob パターンをシングルクォーテーションで囲みました
https://qiita.com/Tsuyoshi84/items/7c80851371b4bee48de4

## 👀 重点的にレビューしてほしいところ・気になっているところ

- 特になし

## 📸 動作確認

- 特になし
