### PR TITLE
Cse 2501 gen expect sql

### DIFF
--- a/src/lib/SQL.ts
+++ b/src/lib/SQL.ts
@@ -88,4 +88,17 @@ export class SQL {
       ', '
     )}) VALUES\n  ${insertValueTexts.join(',\n  ')}\n;`;
   };
+
+  public generateExpectSQLFile = (config: TestConfig['expects'][0]): void => {
+    const schema = config.columns;
+
+    const sqlText = `SELECT ${schema.join(', ')} FROM "${
+      config.srcTable
+    }" EXCEPT SELECT ${schema.join(', ')} FROM "${config.expectTable}"`;
+
+    const sqlFile = new File(
+      path.join(this.targetPackagePath, `/sql/expect/${config.srcTable}.sql`)
+    );
+    sqlFile.write(sqlText);
+  };
 }

--- a/src/lib/SQL.ts
+++ b/src/lib/SQL.ts
@@ -90,11 +90,12 @@ export class SQL {
   };
 
   public generateExpectSQLFile = (config: TestConfig['expects'][0]): void => {
-    const schema = config.columns;
+    const schemas = config.columns;
+    const schemaWithQuote = schemas.map(schema => `"${schema}"`);
 
-    const sqlText = `SELECT ${schema.join(', ')} FROM "${
+    const sqlText = `SELECT ${schemaWithQuote.join(', ')} FROM "${
       config.srcTable
-    }" EXCEPT SELECT ${schema.join(', ')} FROM "${config.expectTable}"`;
+    }" EXCEPT SELECT ${schemaWithQuote.join(', ')} FROM "${config.expectTable}"`;
 
     const sqlFile = new File(
       path.join(this.targetPackagePath, `/sql/expect/${config.srcTable}.sql`)

--- a/src/lib/TestManager.ts
+++ b/src/lib/TestManager.ts
@@ -35,6 +35,10 @@ export class TestManager {
     this.log.printText(``);
     this.generateCreateTableSQLFiles();
     this.log.printText(``);
+
+    // テスト用の SQL ファイルを作成
+    this.generateExpectSQLFiles();
+    this.log.printText(``);
   };
 
   private deletePackageDirectory = (): void => {
@@ -60,6 +64,22 @@ export class TestManager {
 
       this.log.printBuildText(
         path.join(this.targetPackagePath, `/sql/${table.name}.sql`),
+        `Builded`
+      );
+    });
+  };
+
+  private generateExpectSQLFiles = (): void => {
+    this.config.expects.forEach(expect => {
+      const sql = new SQL(
+        path.join(this.directoryPath, this.resourceRootPath),
+        path.join(this.directoryPath, this.targetPackagePath)
+      );
+
+      sql.generateExpectSQLFile(expect);
+
+      this.log.printBuildText(
+        path.join(this.targetPackagePath, `/sql/expect/${expect.srcTable}.sql`),
         `Builded`
       );
     });

--- a/test/lib/TestManager.spec.ts
+++ b/test/lib/TestManager.spec.ts
@@ -71,4 +71,24 @@ describe('TestManager', () => {
       });
     });
   });
+
+  describe('generateExpectSQLFiles()', () => {
+    it('Success', () => {
+      const tableNames = ['result_test_table'];
+      const testManager = new TestManager(
+        log,
+        directoryPath,
+        directoryPath + '/config.yaml',
+        './test/lib/testManager/.td-wdk'
+      );
+      testManager['generateExpectSQLFiles']();
+
+      tableNames.forEach(tableName => {
+        const buildFile = new File(directoryPath + `/test/package/sql/expect/${tableName}.sql`);
+        const expectFile = new File(`./test/lib/testManager/${tableName}.sql`);
+
+        expect(buildFile.read()).toBe(expectFile.read());
+      });
+    });
+  });
 });

--- a/test/lib/testManager/result_test_table.sql
+++ b/test/lib/testManager/result_test_table.sql
@@ -1,1 +1,1 @@
-SELECT name, total FROM "result_test_table" EXCEPT SELECT name, total FROM "expect_table"
+SELECT "name", "total" FROM "result_test_table" EXCEPT SELECT "name", "total" FROM "expect_table"

--- a/test/lib/testManager/result_test_table.sql
+++ b/test/lib/testManager/result_test_table.sql
@@ -1,0 +1,1 @@
+SELECT name, total FROM "result_test_table" EXCEPT SELECT name, total FROM "expect_table"


### PR DESCRIPTION
<!-- cspell: disable-next-line-->
<!-- markdownlint-disable MD041-->
## ⛏やったこと

- WFが生成したテーブルと検証用テーブルを比較する SQL の生成機能を実装しました
  - sql のファイル名は yaml の `srcTable` （つまり検査したいWFが生成するテーブル）の名前を使用しています

## 👀 重点的にレビューしてほしいところ・気になっているところ

-

## 📸 動作確認

- 生成ロジックはテストコードで確認。クエリはTDで動くことを確認しました
